### PR TITLE
Fix error when no arguments are parsed

### DIFF
--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -253,6 +253,17 @@ impl<'input, F: Format<SpanType = Raw, Input<'input> = [&'input str]>> ToCooked<
 {
     #[inline]
     fn to_cooked(self, _format: &F, input: &'input [&'input str]) -> Span<Cooked> {
+        trace!(
+            "cooking span, self.start = {}, input.len = {}",
+            self.start,
+            input.len()
+        );
+
+        if self.start == 0 && input.is_empty() {
+            // empty input
+            return Span::<Cooked>::new(0, 0);
+        }
+
         if self.start >= input.len() {
             // start points past the end of the args;
             // use byte offset = total length of whole input minus 1, len = 1

--- a/src/deserialize/error.rs
+++ b/src/deserialize/error.rs
@@ -302,7 +302,10 @@ impl core::fmt::Display for DeserError<'_> {
 
         let mut span_start = self.span.start();
         let mut span_end = self.span.end();
+        trace!("span range = {span_start}..{span_end}");
+
         use alloc::borrow::Cow;
+        use log::trace;
         let mut input_str: Cow<'_, str> = Cow::Borrowed(orig_input_str);
 
         // --- Context-sensitive truncation logic ---

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -31,6 +31,39 @@ fn test_simplest_value_singleton_list_positional() {
 }
 
 #[test]
+fn test_noargs_single_positional() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Args {
+        #[facet(positional)]
+        strings: String,
+    }
+    let err = facet_args::from_slice::<Args>(&[]).unwrap_err();
+    insta::assert_snapshot!(err);
+}
+
+#[test]
+fn test_noargs_vec_positional_default() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Args {
+        #[facet(positional, default)]
+        strings: Vec<String>,
+    }
+    let args = facet_args::from_slice::<Args>(&[]).unwrap();
+    assert!(args.strings.is_empty());
+}
+
+#[test]
+fn test_noargs_vec_positional_no_default() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Args {
+        #[facet(positional)]
+        strings: Vec<String>,
+    }
+    let err = facet_args::from_slice::<Args>(&[]).unwrap_err();
+    insta::assert_snapshot!(err);
+}
+
+#[test]
 #[ignore]
 fn test_value_singleton_list() {
     #[derive(Facet, Debug, PartialEq)]

--- a/tests/snapshots/sequence__noargs_single_positional.snap
+++ b/tests/snapshots/sequence__noargs_single_positional.snap
@@ -1,0 +1,11 @@
+---
+source: tests/sequence.rs
+expression: err
+---
+[31mError:[0m 
+   [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m <unknown>:1:1 [38;5;246m][0m
+   [38;5;246m│[0m
+ [38;5;246m1 │[0m 
+ [38;5;240m  │[0m [31m│[0m 
+ [38;5;240m  │[0m [31m╰[0m[31m─[0m Field 'Args::strings' was not initialized
+[38;5;246m───╯[0m

--- a/tests/snapshots/sequence__noargs_vec_positional.snap
+++ b/tests/snapshots/sequence__noargs_vec_positional.snap
@@ -1,0 +1,11 @@
+---
+source: tests/sequence.rs
+expression: err
+---
+[31mError:[0m 
+   [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m <unknown>:1:1 [38;5;246m][0m
+   [38;5;246m│[0m
+ [38;5;246m1 │[0m 
+ [38;5;240m  │[0m [31m│[0m 
+ [38;5;240m  │[0m [31m╰[0m[31m─[0m Field 'Args::strings' was not initialized
+[38;5;246m───╯[0m

--- a/tests/snapshots/sequence__noargs_vec_positional_no_default.snap
+++ b/tests/snapshots/sequence__noargs_vec_positional_no_default.snap
@@ -1,0 +1,11 @@
+---
+source: tests/sequence.rs
+expression: err
+---
+[31mError:[0m 
+   [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m <unknown>:1:1 [38;5;246m][0m
+   [38;5;246m│[0m
+ [38;5;246m1 │[0m 
+ [38;5;240m  │[0m [31m│[0m 
+ [38;5;240m  │[0m [31m╰[0m[31m─[0m Field 'Args::strings' was not initialized
+[38;5;246m───╯[0m

--- a/tests/snapshots/sequence__seq_empty.snap
+++ b/tests/snapshots/sequence__seq_empty.snap
@@ -1,0 +1,11 @@
+---
+source: tests/sequence.rs
+expression: err
+---
+[31mError:[0m 
+   [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m <unknown>:1:1 [38;5;246m][0m
+   [38;5;246m│[0m
+ [38;5;246m1 │[0m 
+ [38;5;240m  │[0m [31m│[0m 
+ [38;5;240m  │[0m [31m╰[0m[31m─[0m Field 'Args::strings' was not initialized
+[38;5;246m───╯[0m


### PR DESCRIPTION
When cooking the span, it used to give us a (0,1) span even though the byte slice of the input was empty. Now it does (0,0).

Closes https://github.com/facet-rs/facet-args/issues/1